### PR TITLE
Increasing Event Loop's thread stack.

### DIFF
--- a/ns_event_loop.c
+++ b/ns_event_loop.c
@@ -16,7 +16,7 @@ static void event_loop_thread(const void *arg);
 
 // 1K should be enough - it's what the SAM4E port uses...
 // What happened to the instances parameter?
-static osThreadDef(event_loop_thread, osPriorityNormal, /*1,*/ 2048);
+static osThreadDef(event_loop_thread, osPriorityNormal, /*1,*/ 5120);
 static osMutexDef(event);
 
 static osThreadId event_thread_id;


### PR DESCRIPTION
mbed Client is now using event loop for managing its aync calls
including timer and network calls. However, doing mbedTLS operations
in network callbacks is stack intensive operation and initial stack size
of 2048 bytes is not sufficient, hence increasing the size of thread stack to 5k
to accomodate mbedTLS operations.
