### PR TITLE
Increase stack size to 6K

### DIFF
--- a/ns_event_loop.c
+++ b/ns_event_loop.c
@@ -16,7 +16,7 @@ static void event_loop_thread(const void *arg);
 
 // 1K should be enough - it's what the SAM4E port uses...
 // What happened to the instances parameter?
-static osThreadDef(event_loop_thread, osPriorityNormal, /*1,*/ 5120);
+static osThreadDef(event_loop_thread, osPriorityNormal, /*1,*/ 6*1024);
 static osMutexDef(event);
 
 static osThreadId event_thread_id;


### PR DESCRIPTION
Tests have shown secure DTLS connection failures using LWiP with the 5K
stack. 6K seems to work.
