### PR TITLE
Add "init" call

### DIFF
--- a/ns_hal_init.c
+++ b/ns_hal_init.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016 ARM Limited, All Rights Reserved
+ */
+
+#include "ns_types.h"
+#include <stdlib.h>
+#include <assert.h>
+
+#include "eventOS_scheduler.h"
+#include "ns_event_loop.h"
+#include "randLIB.h"
+#include "platform/arm_hal_timer.h"
+#include "ns_trace.h"
+
+#include "ns_hal_init.h"
+
+void ns_hal_init(void *heap, size_t h_size, void (*passed_fptr)(heap_fail_t), mem_stat_t *info_ptr)
+{
+    static bool initted;
+    if (initted) {
+        return;
+    }
+    if (!heap) {
+        heap = malloc(h_size);
+        assert(heap);
+        if (!heap) {
+            return;
+        }
+    }
+    ns_dyn_mem_init(heap, h_size, passed_fptr, info_ptr);
+    platform_timer_enable();
+    eventOS_scheduler_init();
+    // We do not initialise randlib, as it should be done after
+    // RF driver has started, to get MAC address and RF noise as seed.
+    // We do not initialise trace - left to application.
+    ns_event_loop_thread_create();
+    ns_event_loop_thread_start();
+    initted = true;
+}

--- a/ns_hal_init.h
+++ b/ns_hal_init.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016 ARM Limited, All Rights Reserved
+ */
+
+#ifndef NS_HAL_INIT_H_
+#define NS_HAL_INIT_H_
+
+#include <stddef.h>
+#include "nsdynmemLIB.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialise core Nanostack HAL components.
+ *
+ * Calls after the first do nothing. So "major" users should make sure
+ * they call this first with a "large" heap size, before anyone
+ * requests a smaller one.
+ *
+ * Parameters are as for ns_dyn_mem_init (but note that nsdynmemlib
+ * currently limits heap size to 16-bit, so be wary of passing large
+ * sizes.
+ *
+ * If heap is NULL, h_size will be allocated from the malloc() heap,
+ * else the passed-in pointer will be used.
+ */
+void ns_hal_init(void *heap, size_t h_size, void (*passed_fptr)(heap_fail_t), mem_stat_t *info_ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NS_HAL_INIT_H_ */


### PR DESCRIPTION
To cope with multiple clients needing to start up the nanostack HAL core,
add a central "initialise" call.
