### PR TITLE
Make interrupt context a thread

### DIFF
--- a/arm_hal_interrupt.c
+++ b/arm_hal_interrupt.c
@@ -2,32 +2,29 @@
  * Copyright (c) 2016 ARM Limited, All Rights Reserved
  */
 
-#include "cmsis.h"
-
 #include "arm_hal_interrupt.h"
+#include "arm_hal_interrupt_private.h"
+#include "cmsis_os.h"
+
 
 static uint8_t sys_irq_disable_counter;
 
+static osMutexDef(critical);
+static osMutexId critical_mutex_id;
+
+void platform_critical_init(void)
+{
+    critical_mutex_id = osMutexCreate(osMutex(critical));
+}
+
 void platform_enter_critical(void)
 {
-    __disable_irq();
+    osMutexWait(critical_mutex_id, osWaitForever);
     sys_irq_disable_counter++;
 }
 
 void platform_exit_critical(void)
 {
-    if(--sys_irq_disable_counter == 0) {
-        __enable_irq();
-    }
-}
-
-void platform_interrupts_disabled(void)
-{
-    sys_irq_disable_counter++;
-}
-
-void platform_interrupts_enabling(void)
-{
     --sys_irq_disable_counter;
+    osMutexRelease(critical_mutex_id);
 }
-

--- a/arm_hal_interrupt_private.h
+++ b/arm_hal_interrupt_private.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2016 ARM Limited, All Rights Reserved
+ */
+
+#ifndef ARM_HAL_INTERRUPT_PRIVATE_H_
+#define ARM_HAL_INTERRUPT_PRIVATE_H_
+
+void platform_critical_init(void);
+
+#endif

--- a/ns_hal_init.c
+++ b/ns_hal_init.c
@@ -12,6 +12,7 @@
 #include "platform/arm_hal_timer.h"
 #include "ns_trace.h"
 
+#include "arm_hal_interrupt_private.h"
 #include "ns_hal_init.h"
 
 void ns_hal_init(void *heap, size_t h_size, void (*passed_fptr)(heap_fail_t), mem_stat_t *info_ptr)
@@ -27,6 +28,7 @@ void ns_hal_init(void *heap, size_t h_size, void (*passed_fptr)(heap_fail_t), me
             return;
         }
     }
+    platform_critical_init();
     ns_dyn_mem_init(heap, h_size, passed_fptr, info_ptr);
     platform_timer_enable();
     eventOS_scheduler_init();


### PR DESCRIPTION
Reduce interrupt latency problems by making Nanostack's background context
a high-priority thread, rather than interrupts.

Therefore timer callbacks are now from the high priority thread, and
platform_enter_critical now claims a mutex.

Drivers need a corresponding change to call Nanostack from a thread,
rather than from interrupt.
